### PR TITLE
Fixed issue preventing properties having unreserved underscored names.

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/impl/api/Support.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/api/Support.java
@@ -2,7 +2,10 @@ package com.theoryinpractise.halbuilder.impl.api;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import org.jdom.Namespace;
+
+import java.util.Set;
 
 public class Support {
 
@@ -21,6 +24,7 @@ public class Support {
     public static final String TITLE = "title";
     public static final String HREFLANG = "hreflang";
     public static final String TEMPLATED = "templated";
+    public static final Set<String> RESERVED_JSON_PROPERTIES = ImmutableSet.of(EMBEDDED, LINKS);
 
     /**
      * Define the XML schema instance namespace, so we can use it when
@@ -34,5 +38,4 @@ public class Support {
         Preconditions.checkArgument(rel != null, "Provided rel should not be null.");
         Preconditions.checkArgument(!"".equals(rel) && !rel.contains(" "), "Provided rel value should be a single rel type, as defined by http://tools.ietf.org/html/rfc5988");
     }
-
 }

--- a/src/main/java/com/theoryinpractise/halbuilder/impl/json/JsonRepresentationReader.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/json/JsonRepresentationReader.java
@@ -6,13 +6,21 @@ import com.theoryinpractise.halbuilder.api.ReadableRepresentation;
 import com.theoryinpractise.halbuilder.api.RepresentationException;
 import com.theoryinpractise.halbuilder.api.RepresentationFactory;
 import com.theoryinpractise.halbuilder.api.RepresentationReader;
+import com.theoryinpractise.halbuilder.impl.api.Support;
 import com.theoryinpractise.halbuilder.impl.representations.MutableRepresentation;
 
 import java.io.Reader;
 import java.util.Iterator;
 import java.util.Map;
 
-import static com.theoryinpractise.halbuilder.impl.api.Support.*;
+import static com.theoryinpractise.halbuilder.impl.api.Support.CURIE;
+import static com.theoryinpractise.halbuilder.impl.api.Support.EMBEDDED;
+import static com.theoryinpractise.halbuilder.impl.api.Support.HREF;
+import static com.theoryinpractise.halbuilder.impl.api.Support.HREFLANG;
+import static com.theoryinpractise.halbuilder.impl.api.Support.LINKS;
+import static com.theoryinpractise.halbuilder.impl.api.Support.NAME;
+import static com.theoryinpractise.halbuilder.impl.api.Support.PROFILE;
+import static com.theoryinpractise.halbuilder.impl.api.Support.TITLE;
 
 public class JsonRepresentationReader implements RepresentationReader {
     private RepresentationFactory representationFactory;
@@ -106,7 +114,7 @@ public class JsonRepresentationReader implements RepresentationReader {
         Iterator<String> fieldNames = rootNode.fieldNames();
         while (fieldNames.hasNext()) {
             String fieldName = fieldNames.next();
-            if (!fieldName.startsWith("_")) {
+            if (!Support.RESERVED_JSON_PROPERTIES.contains(fieldName)) {
                 JsonNode field = rootNode.get(fieldName);
                 resource.withProperty(fieldName, field.isNull() ? null : field.asText());
             }

--- a/src/test/java/com/theoryinpractise/halbuilder/ResourceReaderTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/ResourceReaderTest.java
@@ -49,6 +49,13 @@ public class ResourceReaderTest {
         };
     }
 
+    @DataProvider
+    public Object[][] provideResourceWithUnderscoredProperty() {
+        return new Object[][]{
+                {representationFactory.readRepresentation(new InputStreamReader(ResourceReaderTest.class.getResourceAsStream("/exampleWithUnderscoredProperty.json")))},
+        };
+    }
+
     @Test(dataProvider = "provideResources")
     public void testReader(ReadableRepresentation representation) {
         assertThat(representation.getResourceLink().getHref()).isEqualTo("https://example.com/api/customer/123456");
@@ -93,6 +100,11 @@ public class ResourceReaderTest {
         assertThat(representation.getNamespaces()).hasSize(0);
         assertThat(representation.getCanonicalLinks()).hasSize(0);
         assertThat(representation.getValue("name")).isEqualTo("Example Resource");
+    }
+
+    @Test(dataProvider = "provideResourceWithUnderscoredProperty")
+    public void testResourceWithUnderscoredProperty(ReadableRepresentation representation) {
+        assertThat(representation.getValue("_name")).isEqualTo("Example Resource");
     }
 
     @Test(expectedExceptions = RepresentationException.class)


### PR DESCRIPTION
Unreserved underscored properties are now accessible when reading json resources.

This is inline with the spec, see:
http://tools.ietf.org/html/draft-kelly-json-hal-05#appendix-B.4

> B.4.  Are all underscore-prefixed properties reserved?
> No, HAL only reserves the names detailed in this specification."
