### PR TITLE
Implement hypertext cache pattern.

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/impl/representations/MutableRepresentation.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/representations/MutableRepresentation.java
@@ -136,6 +136,14 @@ public class MutableRepresentation extends BaseRepresentation implements Represe
     public MutableRepresentation withRepresentation(String rel, ReadableRepresentation resource) {
         Support.checkRelType(rel);
         resources.put(rel, resource);
+
+        if(representationFactory.getFlags().contains(RepresentationFactory.HYPERTEXT_CACHE_PATTERN)) {
+            Link selfLink = resource.getLinkByRel("self");
+            if (selfLink != null) {
+                withLink(rel, selfLink.getHref(), selfLink.getName(), selfLink.getTitle(), selfLink.getHreflang(), selfLink.getProfile());
+            }
+        }
+
         // Propagate null property flag to parent.
         if (resource.hasNullProperties()) {
             hasNullProperties = true;

--- a/src/test/java/com/theoryinpractise/halbuilder/HypertextCachePatternTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/HypertextCachePatternTest.java
@@ -1,0 +1,54 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package com.theoryinpractise.halbuilder;
+
+import com.theoryinpractise.halbuilder.api.Link;
+import com.theoryinpractise.halbuilder.api.Representation;
+import com.theoryinpractise.halbuilder.api.RepresentationFactory;
+
+import org.testng.annotations.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+/**
+ *
+ * @author pete.johanson
+ */
+public class HypertextCachePatternTest {
+    @Test
+    public void testNonHypertextCachePattern() {
+        RepresentationFactory f = new DefaultRepresentationFactory();
+        
+        Representation embed = f.newRepresentation("/foo");
+        Representation resource = f.newRepresentation("/bar").withRepresentation("foo", embed);
+        
+        assertThat(resource.getLinkByRel("foo"))
+                .isNull();
+    }
+    
+    @Test
+    public void testHypertextCachePattern() {
+        RepresentationFactory f = new DefaultRepresentationFactory().withFlag(RepresentationFactory.HYPERTEXT_CACHE_PATTERN);
+        
+        Representation embed = f.newRepresentation("/foo");
+        Representation resource = f.newRepresentation("/bar").withRepresentation("foo", embed);
+        
+        assertThat(resource.getLinkByRel("foo"))
+                .isEqualTo(new Link(f, "foo", "/foo"));
+    }
+    
+    @Test
+    public void testHypertextCachePatternWithoutSelfRelInEmbedded() {
+        RepresentationFactory f = new DefaultRepresentationFactory().withFlag(RepresentationFactory.HYPERTEXT_CACHE_PATTERN);
+        
+        Representation embed = f.newRepresentation();
+        Representation resource = f.newRepresentation("/bar").withRepresentation("foo", embed);
+        
+        assertThat(resource.getLinkByRel("foo"))
+                .isNull();
+    }
+}


### PR DESCRIPTION
- withRepresentation now checks HYPERTEXT_CACHE_PATTERN flag
  and adds embedded resource's 'self' link to links with same rel.
- See https://tools.ietf.org/html/draft-kelly-json-hal-06#section-8.3

This depends on a small change to halbuilder-api I will be creating a pull request for momentarily.
