### PR TITLE
ResourceRepresentation::withLinks drops existing links

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder5/ResourceRepresentation.java
+++ b/src/main/java/com/theoryinpractise/halbuilder5/ResourceRepresentation.java
@@ -269,7 +269,7 @@ public final class ResourceRepresentation<V> implements Value<V> {
                 rels,
                 (accum, rel) -> !accum.containsKey(rel) ? rels.put(rel, Rels.natural(rel)) : rels);
 
-    final List<Link> updatedLinks = links.appendAll(links);
+    final List<Link> updatedLinks = this.links.appendAll(links);
     return new ResourceRepresentation<>(
         content, updatedLinks, updatedRels, namespaceManager, value, resources);
   }

--- a/src/test/java/com/theoryinpractise/halbuilder5/ResourceRepresentationTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder5/ResourceRepresentationTest.java
@@ -4,6 +4,7 @@ import com.damnhandy.uri.template.UriTemplate;
 import com.jayway.jsonpath.JsonPath;
 import com.theoryinpractise.halbuilder5.json.JsonRepresentationReader;
 import com.theoryinpractise.halbuilder5.json.JsonRepresentationWriter;
+import io.vavr.collection.List;
 import io.vavr.Function1;
 import io.vavr.Function2;
 import io.vavr.collection.HashMap;
@@ -40,6 +41,26 @@ public class ResourceRepresentationTest {
   @Test
   public void testNonEmptyRepresentationIsNotEmpty() {
     assertThat(ResourceRepresentation.create("value").isEmpty()).isFalse();
+  }
+
+  @Test
+  public void testRepresentationLinks() {
+    assertThat(
+            ResourceRepresentation.create("value")
+                .withLink("link", "/link")
+                .getLinkByRel("link")
+                .map(Links::getHref)
+                .get())
+        .isEqualTo("/link");
+
+    assertThat(
+            ResourceRepresentation.create("/self", "value")
+                .withLinks(
+                    List.of(Links.create("link1", "/link1"), Links.create("link2", "/link2")))
+                .getLinkByRel(ResourceRepresentation.SELF)
+                .map(Links::getHref)
+                .get())
+        .isEqualTo("/self");
   }
 
   @Test


### PR DESCRIPTION
In [ResourceRepresentation](https://github.com/HalBuilder/halbuilder-core/blob/799335ddb23a28288fd74841dee3d226bd0fc28b/src/main/java/com/theoryinpractise/halbuilder5/ResourceRepresentation.java#L272) the `.withLinks` method creates a new representation without any of the existing links because the given `links` list is appended to itself instead of the instance property of the same name.